### PR TITLE
Added --set flag to disable PSP 

### DIFF
--- a/dandi-info/z2jh.yml
+++ b/dandi-info/z2jh.yml
@@ -441,7 +441,7 @@
       - name: Add termination handler
         shell: helm upgrade --install aws-node-termination-handler \
           --namespace kube-system \
-          eks/aws-node-termination-handler
+          eks/aws-node-termination-handler --set rbac.pspEnabled=false
 
       # configure and create jupyterhub
       - name: Create security token


### PR DESCRIPTION
This flags disables the use of the Pod Security Policy in the installation of the aws-node-termination-handler giving a v1beta1 version error. 
This is just a hack put in place to remember the issue #52. See issue's description for more detailed information.  