### PR TITLE
changes required for a new hub deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ subdomain, just be sure to set this to the same value as `ingress` in
     - AmazonRoute53FullAccess
     - AmazonEventBridgeFullAccess
 
-1. Add the public dns name to the `dandi-info/hosts` file (This is an Ansible Inventory file.)
+1. Add the public dns name to the `hosts` file (This is an Ansible Inventory file.)
 
 1. SSH into the ec2 instance (using the pem key downloaded in previous
    step) and **install git in the CI instance** `sudo yum install git -y`
@@ -75,7 +75,7 @@ subdomain, just be sure to set this to the same value as `ingress` in
     1. Also note that `namespace` has to be unique across any JH
        instances created with this setup.
 
-1. Ensure `dandi-info/z2jh.yaml` uses the `ig-policy` in the file. (This
+1. Ensure `z2jh.yaml` uses the `ig-policy` in the file. (This
    is not necessary to change if there is already an instance of the
    policy in AWS. If you need to create `ig-policy` use the following:
 
@@ -122,9 +122,7 @@ ansible-playbook -i hosts teardown.yml -v --vault-password-file ansible_password
   pre-modification step.
 - Step outside, commit changes, and either push or send a PR to Dandihub.
 
-## `dandi-info` Files
-
-For reference, the following files are located in the `dandi-info` subfolder:
+## Files
 
 - `group_vars/all`: ansible file contains variables for various templates
 - `cluster-autoscaler-multi-asg.yaml.j2`: k8s cluster autoscaler spec

--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -15,7 +15,7 @@ proxy:
 hub:
   extraConfig:
     myConfig: |
-      from kubernetes import client
+      from kubernetes_asyncio import client
       def modify_pod_hook(spawner, pod):
           pod.spec.containers[0].security_context = client.V1SecurityContext(
               privileged=True
@@ -133,6 +133,9 @@ cull:
   timeout: 3600
   every: 300
 
+debug:
+  enabled: true
+
 singleuser:
   defaultUrl: "/lab"
   image:
@@ -144,12 +147,12 @@ singleuser:
   cpu:
     limit: 12
     guarantee: 0.5
-  startTimeout: 1200
+  startTimeout: 2400
   profileList:
     - display_name: "Tiny. Useful for many quick things"
       description: "0.5 CPU / 1 GB"
       kubespawner_override:
-        singleuser_image_spec: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
+        image: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
         image_pull_policy: Always
         cpu_limit: 2
         cpu_guarantee: 0.25
@@ -159,7 +162,7 @@ singleuser:
       description: "6 CPU / 16 GB upto 12C/32G. May take up to 15 mins to start."
       default: true
       kubespawner_override:
-        singleuser_image_spec: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
+        image: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
         image_pull_policy: Always
         cpu_limit: 12
         cpu_guarantee: 6
@@ -168,7 +171,7 @@ singleuser:
     - display_name: "Medium"
       description: "12C/32G upto 24C/64G. May take up to 15 mins to start."
       kubespawner_override:
-        singleuser_image_spec: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
+        image: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
         image_pull_policy: Always
         cpu_limit: 24
         cpu_guarantee: 12
@@ -177,7 +180,7 @@ singleuser:
     - display_name: "Large"
       description: "24C/64G upto 48C/96G. May take up to 15 mins to start."
       kubespawner_override:
-        singleuser_image_spec: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
+        image: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}'
         image_pull_policy: Always
         cpu_limit: 48
         cpu_guarantee: 24
@@ -186,7 +189,7 @@ singleuser:
     - display_name: "T4 GPU for inference"
       description: "4 CPU / 15 GB / 1 T4 GPU. May take up to 15 mins to start."
       kubespawner_override:
-        singleuser_image_spec: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}-gpu'
+        image: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}-gpu'
         image_pull_policy: Always
         cpu_limit: 4
         cpu_guarantee: 2
@@ -199,7 +202,7 @@ singleuser:
     - display_name: "Base (MATLAB)"
       description: "6 CPU / 16 GB upto 12C/32G. May take up to 15 mins to start. This requires your own license."
       kubespawner_override:
-        singleuser_image_spec: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}-matlab'
+        image: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}-matlab'
         image_pull_policy: Always
         cpu_limit: 12
         cpu_guarantee: 6

--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -133,9 +133,6 @@ cull:
   timeout: 3600
   every: 300
 
-debug:
-  enabled: true
-
 singleuser:
   defaultUrl: "/lab"
   image:

--- a/group_vars/all
+++ b/group_vars/all
@@ -9,7 +9,7 @@ node_count: 1
 max_node: 5
 max_spot: 50
 max_spot_gpu: 50
-jupyterhub_chart_version: 1.2.0
+jupyterhub_chart_version: 2.0.1-0.dev.git.6023.h2a02c402
 singleuser_image_repo: dandiarchive/dandihub
 singleuser_image_tag: latest
 helm_chart_repo_name: jupyterhub

--- a/z2jh.yml
+++ b/z2jh.yml
@@ -469,7 +469,7 @@
         changed_when: False
 
       - name: Install JupyterHub release
-        shell: helm upgrade --install {{ namespace }}-jupyterhub {{ helm_chart_repo_name }}/jupyterhub \
+        shell: helm --install {{ namespace }}-jupyterhub {{ helm_chart_repo_name }}/jupyterhub \
           --debug \
           --version={{ jupyterhub_chart_version }} \
           --namespace={{ namespace }} \

--- a/z2jh.yml
+++ b/z2jh.yml
@@ -469,7 +469,7 @@
         changed_when: False
 
       - name: Install JupyterHub release
-        shell: helm --install {{ namespace }}-jupyterhub {{ helm_chart_repo_name }}/jupyterhub \
+        shell: helm install {{ namespace }}-jupyterhub {{ helm_chart_repo_name }}/jupyterhub \
           --debug \
           --version={{ jupyterhub_chart_version }} \
           --namespace={{ namespace }} \

--- a/z2jh.yml
+++ b/z2jh.yml
@@ -469,7 +469,7 @@
         changed_when: False
 
       - name: Install JupyterHub release
-        shell: helm install {{ namespace }}-jupyterhub {{ helm_chart_repo_name }}/jupyterhub \
+        shell: helm upgrade --install {{ namespace }}-jupyterhub {{ helm_chart_repo_name }}/jupyterhub \
           --debug \
           --version={{ jupyterhub_chart_version }} \
           --namespace={{ namespace }} \


### PR DESCRIPTION
from trying to deploy a new hub separately for the first time, discovered these changes to be made: 
- jupyterhub chart version update
- helm upgrade 
- kubernetes library import renamed to kubernetes_asyncio (from jupyterhub version update)
- singleuser_image_spec renamed to image (from new kubespawner version, @satra can you confirm you made this diff from dandi hub to kb hub? i double-checked from rerunning it but just to confirm)
- debug mode enabled 
- increased timeout duration

https://docs.google.com/document/d/1SC08Vd38z3vGfaYGYZYwdCN_ZHRBWpSHkb4aQ9JzQ1o/edit#heading=h.i3nokrj0xsid