### PR TITLE
Feature/addon latest mechanism

### DIFF
--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -13,7 +13,7 @@ RUN wget -q https://github.com/apptainer/apptainer/releases/download/v${VERSION}
 RUN apt-get update && apt-get install -y ca-certificates libseccomp2 \
    uidmap squashfs-tools squashfuse fuse2fs fuse-overlayfs fakeroot \
    s3fs netbase less parallel tmux screen vim emacs htop curl \
-   git build-essential cargo \
+   git build-essential \
    && rm -rf /tmp/*
 
 RUN curl --silent --show-error "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \

--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -13,7 +13,7 @@ RUN wget -q https://github.com/apptainer/apptainer/releases/download/v${VERSION}
 RUN apt-get update && apt-get install -y ca-certificates libseccomp2 \
    uidmap squashfs-tools squashfuse fuse2fs fuse-overlayfs fakeroot \
    s3fs netbase less parallel tmux screen vim emacs htop curl \
-   git build-essential \
+   git build-essential cargo \
    && rm -rf /tmp/*
 
 RUN curl --silent --show-error "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \

--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -102,6 +102,12 @@ ARG ADDONS_LATEST="https://github.com/emeyers/Brain-Observatory-Toolbox"
 RUN cd ${ADDONS_DIR} && \
     for addon in $ADDONS_LATEST; do \
        wget -O addon.zip $(echo "$addon/releases/latest" | sed 's/\/github.com\//\/api.github.com\/repos\//' | xargs wget -qO- |  grep zipball_url | cut -d '"' -f 4) \
-       && unzip addon.zip \
+       && unzip addon.zip; \
+       echo -e "\n\
+add_path(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)quickstarts\"); \n\
+add_path(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)demos\"); \n\
+add_path(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)tutorials\");\n\
+clear" >> /opt/conda/lib/python3.10/site-packages/matlab_proxy/matlab/startup.m \
        && rm addon.zip; \
     done
+# The copy of the quickstarts/demos/tutorials folder in the startup.m file are temporary

--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -104,9 +104,9 @@ RUN cd ${ADDONS_DIR} && \
        wget -O addon.zip $(echo "$addon/releases/latest" | sed 's/\/github.com\//\/api.github.com\/repos\//' | xargs wget -qO- |  grep zipball_url | cut -d '"' -f 4) \
        && unzip addon.zip; \
        echo -e "\n\
-add_path(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)quickstarts\"); \n\
-add_path(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)demos\"); \n\
-add_path(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)tutorials\");\n\
+addpath(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)quickstarts\"); \n\
+addpath(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)demos\"); \n\
+addpath(\"${ADDONS_DIR}/$(unzip -Z -1 addon.zip | head -1)tutorials\");\n\
 clear" >> /opt/conda/lib/python3.10/site-packages/matlab_proxy/matlab/startup.m \
        && rm addon.zip; \
     done

--- a/docker/README.adoc
+++ b/docker/README.adoc
@@ -105,5 +105,8 @@ You can impact those parameters:
 This variable defines where the add-ons must be downloaded/extracted and what will be the folder scanned by MATLAB at startup time.
 If you change this folder, the Jupyter user needs to have read/write access to it. This comes from a specificity of `matnwb` which requires the execution of some extra actions for its activation.
 
-`ADDONS`::
+`ADDONS_RELEASE`::
 This variable defines the list of add-ons to download and install. You can add as much add-ons as you want as long as they are compatible with MATLAB-R22.
+
+`ADDONS_LATEST`::
+This variable defines the list of add-ons to download and install directly from the lastest version identified in the github repository.


### PR DESCRIPTION
This PR provides a way to differenciate, during the MATLAB Docker image build, addons that need to be included with a dedicated version from addons that need to be included using their last version each build. 

Currently, `nwb` is included with a fixed version, while the last release version of BOT will be always gathered during the build. It's possible to add many other plugins either as fixed version, or as "last release" version.

The PR is currently in a draft mode as we are still conducting tests. The image builds perfectly and it has been tested in a debian 11 VirtualBox image hosted by an archlinux. More tests are currently conducted, and as soon as they are finished, I'll open the PR to be merged.
