### PR TITLE
Bump PyNWB and NWB Widgets versions to latest fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN /opt/conda/envs/allen/bin/python -m ipykernel install --user --name allen \
 
 RUN pip install --no-cache-dir -U plotly jupyter_bokeh jupytext nbgitpuller datalad_container \
     datalad-osf dandi nibabel nilearn pybids spikeinterface neo itkwidgets \
-    'pydra>=0.17' 'pynwb>=2.0.0' 'nwbwidgets>=0.10.1' hdf5plugin s3fs h5netcdf "xarray[io]"  \
+    'pydra>=0.17' 'pynwb>=2.3.1' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]"  \
     aicsimageio kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr \
     webio_jupyter_extension https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip \
     tensorstore anndata

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -64,7 +64,7 @@ RUN /opt/conda/envs/allen/bin/python -m ipykernel install --user --name allen \
 
 RUN pip install --no-cache-dir -U plotly jupyter_bokeh jupytext nbgitpuller datalad_container \
     datalad-osf dandi nibabel nilearn pybids spikeinterface neo itkwidgets \
-    'pydra>=0.17' 'pynwb>=2.0.0' 'nwbwidgets>=0.10.1' hdf5plugin s3fs h5netcdf "xarray[io]"  \
+    'pydra>=0.17' 'pynwb>=2.3.1' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]"  \
     aicsimageio kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr \
     webio_jupyter_extension https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip \
     tensorstore anndata

--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -59,7 +59,7 @@ RUN mamba install --yes 'datalad>=0.18' rclone 'h5py>3.3=mpi*' ipykernel zarr bl
 
 RUN pip install --no-cache-dir plotly jupyter_bokeh jupytext nbgitpuller datalad_container \
     datalad-osf dandi nibabel nilearn pybids spikeinterface neo \
-    'pydra>=0.17' 'pynwb>=2.0.0' 'nwbwidgets>=0.10.1' hdf5plugin s3fs h5netcdf "xarray[io]"  \
+    'pydra>=0.17' 'pynwb>=2.3.1' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]"  \
     aicsimageio kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr \
     webio_jupyter_extension https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip \
     tensorstore anndata


### PR DESCRIPTION
@satra As requested, though I don't see the command that sets these installations for the `ipykernel` jupyter kernel specifically - assuming that simply runs on the base installations