### PR TITLE
Change the way the example live scripts are copied

### DIFF
--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -99,9 +99,6 @@ RUN ./mpm install \
 # Switch back to NB_USER for addons and live-scripts installations
 USER $NB_USER
 
-# Install the live-scripts examples
-RUN git clone https://github.com/INCF/example-live-scripts
-
 ## Adds add-ons and register them in the Matlab instance
 # Patch startup.m to automatically register the addons
 # The registration process simply iterate over all entries from the ADDONS_DIR folder
@@ -109,12 +106,21 @@ RUN git clone https://github.com/INCF/example-live-scripts
 ARG ADDONS_DIR=${EXTRA_DIR}/dandi
 ARG STARTUP_SCRIPT=/opt/conda/lib/python3.10/site-packages/matlab_proxy/matlab/startup.m
 
+# Install the live-scripts examples
+# RUN git clone https://github.com/INCF/example-live-scripts ${ADDONS_DIR}/example-live-scripts
+
 RUN echo -e "\n\
 % Sets the number of workers for 'Processes' to 5\n\
 cluster = parcluster('Processes'); \n\
 cluster.NumWorkers = 5; \n\
 saveProfile(cluster); \n\
  \n\
+% Copy the live-example folder \n\
+homedirExamples = strcat(getenv('HOME'), '/example-live-scripts') \n\
+if not(isfolder(homedirExamples)) \n\
+    % copyfile('${ADDONS_DIR}/example-live-scripts', homedirExamples) \n\
+    repo = gitclone('https://github.com/INCF/example-live-scripts', homedirExamples, Depth=1); \n\
+end \n\
 % Adds the addons to the path \n\
 addons = dir('${ADDONS_DIR}'); \n\
 addons = setdiff({addons([addons.isdir]).name}, {'.', '..'}); \n\

--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -119,7 +119,8 @@ saveProfile(cluster); \n\
 homedirExamples = strcat(getenv('HOME'), '/example-live-scripts') \n\
 if not(isfolder(homedirExamples)) \n\
     % copyfile('${ADDONS_DIR}/example-live-scripts', homedirExamples) \n\
-    repo = gitclone('https://github.com/INCF/example-live-scripts', homedirExamples, Depth=1); \n\
+    % repo = gitclone('https://github.com/INCF/example-live-scripts', homedirExamples, Depth=1); \n\
+    system(strcat(string('git clone --depth=1 https://github.com/INCF/example-live-scripts '), homedirExamples)) \n\
 end \n\
 % Adds the addons to the path \n\
 addons = dir('${ADDONS_DIR}'); \n\
@@ -138,7 +139,7 @@ ARG ADDONS_RELEASES="https://github.com/NeurodataWithoutBorders/matnwb/archive/r
                      https://github.com/bahanonu/ciatah/archive/refs/heads/master.zip"
 
 # Add add-ons for Dandi: create the addons folder and download/unzip the addons
-RUN mkdir ${ADDONS_DIR} && \
+RUN mkdir -p ${ADDONS_DIR} && \
     cd ${ADDONS_DIR} && \
     for addon in $ADDONS_RELEASES; do \
        wget -O addon.zip $addon \


### PR DESCRIPTION
I realized that the home folder is actually mounted from another directory in a FS somewhere, consequently, all the clones and all files copied during the image build in the home folder are "lost" when the container is ran and the home folder is mounted with the permanent folder for the user.

This modification will clone the live-example-scripts repository when the MATLAB instance is ran (modification of the `startup.m` script), fixing this issue.