### PR TITLE
DM-55 Add GPU powered MATLAB Dockerfile

### DIFF
--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -208,6 +208,19 @@ singleuser:
         cpu_guarantee: 6
         mem_limit: 32G
         mem_guarantee: 16G
+    - display_name: "T4 GPU MATLAB"
+      description: "6 CPU / 16 GB upto 12C/32G / 1 T4 GPU. May take up to 15 mins to start. This requires your own license."
+      kubespawner_override:
+        image: '{{ singleuser_image_repo }}:{{ singleuser_image_tag }}-gpu-matlab'
+        image_pull_policy: Always
+        cpu_limit: 12
+        cpu_guarantee: 6
+        mem_limit: 32G
+        mem_guarantee: 16G
+        extra_resource_limits:
+          nvidia.com/gpu: "1"
+        extra_pod_config:
+          runtimeClassName: nvidia
   storage:
     type: none
     extraVolumes:

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -57,6 +57,8 @@ RUN pip install --no-cache-dir jupyter-remote-desktop-proxy jupyterlab_nvdashboa
 
 RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
   && conda clean --all -f -y && rm -rf /tmp/*
+RUN ONDA_OVERRIDE_CUDA="11.8" mamba install --yes 'tensorflow-gpu' -c conda-forge \
+&& conda clean --all -f -y && rm -rf /tmp/*
 
 RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.7/git-annex-remote-rclone \
@@ -68,7 +70,8 @@ RUN pip install --no-cache-dir plotly jupyter_bokeh jupytext nbgitpuller datalad
     'pydra>=0.17' 'pynwb>=2.3.1' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]"  \
     aicsimageio kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr \
     webio_jupyter_extension https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip \
-    tensorstore anndata "tensorflow[and-cuda]"
+    tensorstore anndata
+# "tensorflow[and-cuda]"
 
 
 # Install tensorflow, cuda and extension for GPU usage display

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -56,8 +56,14 @@ USER $NB_USER
 RUN pip install --no-cache-dir jupyter-remote-desktop-proxy jupyterlab_nvdashboard
 
 # Install CUDA toolkit and extension for GPU usage display
-RUN CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
+RUN CONDA_OVERRIDE_CUDA="12.3" mamba install --yes -c "nvidia/label/cuda-12.3.0" cuda-toolkit cudnn \
   && conda clean --all -f -y && rm -rf /tmp/*
+
+RUN echo -e "\n\
+import os \n\
+os.environ['LD_LIBRARY_PATH'] = '/usr/local/nvidia/lib64' \n\
+c.Spawner.env.update('LD_LIBRARY_PATH') \n\
+" >> ~/.jupyter/jupyter_notebook_config.py
 
 RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.7/git-annex-remote-rclone \
@@ -69,7 +75,7 @@ RUN pip install --no-cache-dir plotly jupyter_bokeh jupytext nbgitpuller datalad
     'pydra>=0.17' 'pynwb>=2.3.1' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]"  \
     aicsimageio kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr \
     webio_jupyter_extension https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip \
-    tensorstore anndata "tensorflow[and-cuda]"
+    tensorstore anndata "tensorflow[and-cuda]==2.14"
 
 # Ensure OpenSSL is up-to-date
 RUN pip install -U pyopenssl

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -56,7 +56,7 @@ USER $NB_USER
 RUN pip install --no-cache-dir jupyter-remote-desktop-proxy jupyterlab_nvdashboard
 
 # Install CUDA toolkit and extension for GPU usage display
-RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
+RUN CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
   && conda clean --all -f -y && rm -rf /tmp/*
 
 RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
@@ -79,28 +79,28 @@ RUN pip install --no-cache-dir jupyter-matlab-proxy
 
 # Install the required Toolboxes with user root
 # Optimization toolbox is a required dependency
-# USER root
-# ARG MATLAB_RELEASE
-# ARG TOOLBOXES="Bioinformatics_Toolbox \
-#                Computer_Vision_Toolbox \
-#                Curve_Fitting_Toolbox \
-#                Deep_Learning_Toolbox \
-#                Econometrics_Toolbox \
-#                Image_Processing_Toolbox \
-#                Optimization_Toolbox \
-#                Statistics_and_Machine_Learning_Toolbox \
-#                Signal_Processing_Toolbox \
-#                Parallel_Computing_Toolbox \
-#                Financial_Toolbox \
-#                Wavelet_Toolbox \
-#                Deep_Learning_Toolbox_Converter_for_TensorFlow_models"
-# RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm && \
-#     chmod +x mpm
-# RUN ./mpm install \
-#     --release=${MATLAB_RELEASE} \
-#     --destination=/opt/matlab \
-#     --products ${TOOLBOXES} && \
-#     rm -f mpm /tmp/mathworks_root.log
+USER root
+ARG MATLAB_RELEASE
+ARG TOOLBOXES="Bioinformatics_Toolbox \
+               Computer_Vision_Toolbox \
+               Curve_Fitting_Toolbox \
+               Deep_Learning_Toolbox \
+               Econometrics_Toolbox \
+               Image_Processing_Toolbox \
+               Optimization_Toolbox \
+               Statistics_and_Machine_Learning_Toolbox \
+               Signal_Processing_Toolbox \
+               Parallel_Computing_Toolbox \
+               Financial_Toolbox \
+               Wavelet_Toolbox \
+               Deep_Learning_Toolbox_Converter_for_TensorFlow_models"
+RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm && \
+    chmod +x mpm
+RUN ./mpm install \
+    --release=${MATLAB_RELEASE} \
+    --destination=/opt/matlab \
+    --products ${TOOLBOXES} && \
+    rm -f mpm /tmp/mathworks_root.log
 
 # Switch back to NB_USER for addons and live-scripts installations
 USER $NB_USER

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -55,10 +55,13 @@ USER $NB_USER
 
 RUN pip install --no-cache-dir jupyter-remote-desktop-proxy jupyterlab_nvdashboard
 
-RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
-  && conda clean --all -f -y && rm -rf /tmp/*
-RUN ONDA_OVERRIDE_CUDA="11.8" mamba install --yes 'tensorflow-gpu' -c conda-forge \
-&& conda clean --all -f -y && rm -rf /tmp/*
+# RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
+#   && conda clean --all -f -y && rm -rf /tmp/*
+# RUN ONDA_OVERRIDE_CUDA="11.8" mamba install --yes 'tensorflow-gpu' -c conda-forge \
+# && conda clean --all -f -y && rm -rf /tmp/*
+
+RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes tensorflow cudatoolkit -c conda-forge \
+    && conda clean --all -f -y && rm -rf /tmp/*
 
 RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.7/git-annex-remote-rclone \

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -55,8 +55,8 @@ USER $NB_USER
 
 RUN pip install --no-cache-dir jupyter-remote-desktop-proxy
 
-# Install tensorflow
-RUN mamba install --yes 'tensorflow<=2.10.0' -c conda-forge \
+# Install tensorflow, cuda and extension for GPU usage display
+RUN CONDA_OVERRIDE_CUDA="11.2" mamba install --yes 'tensorflow-gpu<=2.10.0' 'cudatoolkit>=11.2' -c conda-forge \
   && conda clean --all -f -y && rm -rf /tmp/*
 
 RUN pip install --no-cache-dir jupyterlab_nvdashboard

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -55,13 +55,9 @@ USER $NB_USER
 
 RUN pip install --no-cache-dir jupyter-remote-desktop-proxy jupyterlab_nvdashboard
 
-# RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
-#   && conda clean --all -f -y && rm -rf /tmp/*
-# RUN ONDA_OVERRIDE_CUDA="11.8" mamba install --yes 'tensorflow-gpu' -c conda-forge \
-# && conda clean --all -f -y && rm -rf /tmp/*
-
-RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes tensorflow cudatoolkit -c conda-forge \
-    && conda clean --all -f -y && rm -rf /tmp/*
+# Install CUDA toolkit and extension for GPU usage display
+RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
+  && conda clean --all -f -y && rm -rf /tmp/*
 
 RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.7/git-annex-remote-rclone \
@@ -73,16 +69,7 @@ RUN pip install --no-cache-dir plotly jupyter_bokeh jupytext nbgitpuller datalad
     'pydra>=0.17' 'pynwb>=2.3.1' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]"  \
     aicsimageio kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr \
     webio_jupyter_extension https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip \
-    tensorstore anndata
-# "tensorflow[and-cuda]"
-
-
-# Install tensorflow, cuda and extension for GPU usage display
-# RUN CONDA_OVERRIDE_CUDA="11.8" mamba install --yes 'tensorflow-gpu' 'cudatoolkit>=11.8' -c conda-forge \
-#   && conda clean --all -f -y && rm -rf /tmp/*
-
-
-# RUN CONDA_OVERRIDE_CUDA="11.8" pip install "tensorflow[and-cuda]"
+    tensorstore anndata "tensorflow[and-cuda]"
 
 # Ensure OpenSSL is up-to-date
 RUN pip install -U pyopenssl

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -59,11 +59,11 @@ RUN pip install --no-cache-dir jupyter-remote-desktop-proxy jupyterlab_nvdashboa
 RUN CONDA_OVERRIDE_CUDA="12.3" mamba install --yes -c "nvidia/label/cuda-12.3.0" cuda-toolkit cudnn \
   && conda clean --all -f -y && rm -rf /tmp/*
 
-RUN echo -e "\n\
-import os \n\
-os.environ['LD_LIBRARY_PATH'] = '/usr/local/nvidia/lib64' \n\
-c.Spawner.env.update('LD_LIBRARY_PATH') \n\
-" >> ~/.jupyter/jupyter_notebook_config.py
+# RUN echo -e "\n\
+# import os \n\
+# os.environ['LD_LIBRARY_PATH'] = '/usr/local/nvidia/lib64' \n\
+# c.Spawner.env.update('LD_LIBRARY_PATH') \n\
+# " >> ~/.jupyter/jupyter_notebook_config.py
 
 RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.7/git-annex-remote-rclone \

--- a/docker/Dockerfile.gpu.matlab
+++ b/docker/Dockerfile.gpu.matlab
@@ -53,15 +53,12 @@ RUN mkdir ${EXTRA_DIR} && chown -R $NB_UID:$NB_GID $HOME ${EXTRA_DIR}
 
 USER $NB_USER
 
-RUN pip install --no-cache-dir jupyter-remote-desktop-proxy
+RUN pip install --no-cache-dir jupyter-remote-desktop-proxy jupyterlab_nvdashboard
 
-# Install tensorflow, cuda and extension for GPU usage display
-RUN CONDA_OVERRIDE_CUDA="11.2" mamba install --yes 'tensorflow-gpu<=2.10.0' 'cudatoolkit>=11.2' -c conda-forge \
+RUN CONDA_VERBOSITY=1 CONDA_OVERRIDE_CUDA="11.8" mamba install --yes -c "nvidia/label/cuda-11.8.0" cuda-toolkit cudnn \
   && conda clean --all -f -y && rm -rf /tmp/*
 
-RUN pip install --no-cache-dir jupyterlab_nvdashboard
-
-RUN mamba install --yes 'datalad>=0.18' rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
+RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.7/git-annex-remote-rclone \
   && chmod +x git-annex-remote-rclone && mv git-annex-remote-rclone /opt/conda/bin \
   && conda clean --all -f -y && rm -rf /tmp/*
@@ -71,8 +68,15 @@ RUN pip install --no-cache-dir plotly jupyter_bokeh jupytext nbgitpuller datalad
     'pydra>=0.17' 'pynwb>=2.3.1' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]"  \
     aicsimageio kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr \
     webio_jupyter_extension https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip \
-    tensorstore anndata
+    tensorstore anndata "tensorflow[and-cuda]"
 
+
+# Install tensorflow, cuda and extension for GPU usage display
+# RUN CONDA_OVERRIDE_CUDA="11.8" mamba install --yes 'tensorflow-gpu' 'cudatoolkit>=11.8' -c conda-forge \
+#   && conda clean --all -f -y && rm -rf /tmp/*
+
+
+# RUN CONDA_OVERRIDE_CUDA="11.8" pip install "tensorflow[and-cuda]"
 
 # Ensure OpenSSL is up-to-date
 RUN pip install -U pyopenssl
@@ -82,28 +86,28 @@ RUN pip install --no-cache-dir jupyter-matlab-proxy
 
 # Install the required Toolboxes with user root
 # Optimization toolbox is a required dependency
-USER root
-ARG MATLAB_RELEASE
-ARG TOOLBOXES="Bioinformatics_Toolbox \
-               Computer_Vision_Toolbox \
-               Curve_Fitting_Toolbox \
-               Deep_Learning_Toolbox \
-               Econometrics_Toolbox \
-               Image_Processing_Toolbox \
-               Optimization_Toolbox \
-               Statistics_and_Machine_Learning_Toolbox \
-               Signal_Processing_Toolbox \
-               Parallel_Computing_Toolbox \
-               Financial_Toolbox \
-               Wavelet_Toolbox \
-               Deep_Learning_Toolbox_Converter_for_TensorFlow_models"
-RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm && \
-    chmod +x mpm
-RUN ./mpm install \
-    --release=${MATLAB_RELEASE} \
-    --destination=/opt/matlab \
-    --products ${TOOLBOXES} && \
-    rm -f mpm /tmp/mathworks_root.log
+# USER root
+# ARG MATLAB_RELEASE
+# ARG TOOLBOXES="Bioinformatics_Toolbox \
+#                Computer_Vision_Toolbox \
+#                Curve_Fitting_Toolbox \
+#                Deep_Learning_Toolbox \
+#                Econometrics_Toolbox \
+#                Image_Processing_Toolbox \
+#                Optimization_Toolbox \
+#                Statistics_and_Machine_Learning_Toolbox \
+#                Signal_Processing_Toolbox \
+#                Parallel_Computing_Toolbox \
+#                Financial_Toolbox \
+#                Wavelet_Toolbox \
+#                Deep_Learning_Toolbox_Converter_for_TensorFlow_models"
+# RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm && \
+#     chmod +x mpm
+# RUN ./mpm install \
+#     --release=${MATLAB_RELEASE} \
+#     --destination=/opt/matlab \
+#     --products ${TOOLBOXES} && \
+#     rm -f mpm /tmp/mathworks_root.log
 
 # Switch back to NB_USER for addons and live-scripts installations
 USER $NB_USER

--- a/docker/Dockerfile.matlab
+++ b/docker/Dockerfile.matlab
@@ -61,7 +61,7 @@ RUN mamba install --yes 'tensorflow<=2.10.0' -c conda-forge \
 
 RUN pip install --no-cache-dir jupyterlab_nvdashboard
 
-RUN mamba install --yes 'datalad>=0.18' rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
+RUN mamba install --yes datalad rclone 'h5py>3.3=mpi*' ipykernel zarr blosc gcc eccodes websockify \
   && wget --quiet https://raw.githubusercontent.com/DanielDent/git-annex-remote-rclone/v0.7/git-annex-remote-rclone \
   && chmod +x git-annex-remote-rclone && mv git-annex-remote-rclone /opt/conda/bin \
   && conda clean --all -f -y && rm -rf /tmp/*


### PR DESCRIPTION
This PR adds a Dockerfile for MATLAB targeting GPU architectures (CUDA 11.8), and with the last `tenserflow` with GPU enabled capability installed.

The PR also adds a new entry in the `config.yaml.j2` to run the image associated to the MATLAB GPU Dockerfile.