### PR TITLE
(aspirational  hack project) Auto-generate EFS usage report & Log storage

### DIFF
--- a/scripts/efs-cron-pod.yml
+++ b/scripts/efs-cron-pod.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inspect-pvc-pod
+spec:
+  containers:
+    - name: inspect-pvc-container
+      image: busybox
+      command: ["/bin/sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - name: efs-storage
+          mountPath: /mnt/efs
+      volumes:
+        - name: efs-storage
+          persistentVolumeClaim:
+            claimName: efs-persist

--- a/scripts/efs-cron-pod.yml
+++ b/scripts/efs-cron-pod.yml
@@ -1,17 +1,35 @@
----
 apiVersion: v1
 kind: Pod
 metadata:
   name: inspect-pvc-pod
 spec:
   containers:
-    - name: inspect-pvc-container
-      image: busybox
-      command: ["/bin/sh", "-c", "sleep 3600"]
-      volumeMounts:
-        - name: efs-storage
-          mountPath: /mnt/efs
-      volumes:
-        - name: efs-storage
-          persistentVolumeClaim:
-            claimName: efs-persist
+  - name: inspect-pvc-container
+    image: busybox
+    command:
+      - /bin/sh
+      - -c
+      - |
+        #!/bin/sh
+        set -eux
+
+        # EFS_PERSIST_MNT is the mount point for the PVC
+        EFS_PERSIST_MNT="/mnt/efs-persist"
+        EFS_HOME="$EFS_PERSIST_MNT/home"
+
+        # Generate the size report
+        du -sh $EFS_HOME/* | awk '{print $1, $2}' > $EFS_HOME/size_report.txt
+
+        # Display the size report
+        cat "$EFS_HOME/size_report.txt"
+        
+        # Keep the container running
+        sleep 3600
+    volumeMounts:
+    - name: efs-storage
+      mountPath: /mnt/efs-persist
+  volumes:
+  - name: efs-storage
+    persistentVolumeClaim:
+      claimName: efs-persist
+

--- a/scripts/efs-cron-script.sh
+++ b/scripts/efs-cron-script.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eux
+
+# EFS_PERSIST_MNT = "/mnt/efs-persist"
+EFS_PERSIST_MNT="/tmp/efs-script-dump"
+EFS_HOME="$EFS_PERSIST_MNT/home"
+
+du -sh $EFS_HOME/* | awk '{print $1, $2}' > $EFS_HOME/size_report.txt
+cat $EFS_HOME/size_report.txt


### PR DESCRIPTION
We will run a github action at 1 month intervals (or whatever) that generates the efs-usage report from kubernetes, commits it to a private datalad repo. 

Github action:
  - report generation and retrieve log:  `kubectl apply -f inspect-pvc-pod.yaml && kubectl logs -f $(kubectl get pods -o jsonpath="{.items[?(@.metadata.name=='inspect-pvc-pod')].metadata.name}")` (ish)
  - execution via datalad run (@yarikoptic this is the usecase for datalad publishing some containers)
  - push updated datalad repo to some repo
 
(Side Bonus: GH Action with access to EKS builds towards GitOps goal)