### PR TITLE
Add shellchecking of the shell scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,26 @@
+---
+name: Shellcheck
+
+on:
+  push:
+    branches: [do-eks]
+  pull_request:
+    branches: [do-eks]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y shellcheck
+      - name: shellcheck
+        run: |
+          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' | xargs shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,8 @@ repos:
     hooks:
       - id: flake8
         args: ['--max-line-length=100']
+
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.9.0
+  hooks:
+  - id: shellcheck


### PR DESCRIPTION
This would fail now and fixes are needed (assigning to @asmacdo)

```
❯ shellcheckit doit
cleanup.sh:#!/bin/bash
install.sh:#!/bin/bash
scripts/account-enforcer.sh:#!/bin/bash
scripts/ensure-vars.sh:#!/bin/bash
gh-yarikoptic

In cleanup.sh line 5:
#!/bin/bash
^-- SC1128 (error): The shebang must be on the first line. Delete blanks and move comments.


In cleanup.sh line 34:
terraform workspace select $ENV
                           ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
terraform workspace select "$ENV"


In cleanup.sh line 56:
    kubectl get namespace $ns -o json | sed 's/"kubernetes"//' | kubectl replace --raw "/api/v1/namespaces/$ns/finalize" -f -
                          ^-^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    kubectl get namespace "$ns" -o json | sed 's/"kubernetes"//' | kubectl replace --raw "/api/v1/namespaces/$ns/finalize" -f -


In install.sh line 21:
./scripts/account-enforcer.sh $ENV
                              ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
./scripts/account-enforcer.sh "$ENV"


In install.sh line 27:
BACKEND_FILE="$ENV_DIR/backend.tf"
^----------^ SC2034 (warning): BACKEND_FILE appears unused. Verify use (or export if used externally).


In install.sh line 41:
./scripts/merge_config.py $BASE_CONFIG $ENV_OVERRIDE $OUTPUT
                                       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                     ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
./scripts/merge_config.py $BASE_CONFIG "$ENV_OVERRIDE" "$OUTPUT"


In install.sh line 44:
if [ $? -ne 0 ]; then
     ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In install.sh line 64:
terraform workspace select -or-create $ENV
                                      ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
terraform workspace select -or-create "$ENV"


In install.sh line 99:
$(terraform output -raw configure_kubectl)
^-- SC2091 (warning): Remove surrounding $() to avoid executing output (or use eval if intentional).


In scripts/account-enforcer.sh line 12:
  echo "Environments: ${!ENV_TO_PROFILE[@]}"
                      ^-------------------^ SC2145 (error): Argument mixes string and array. Use * or separate argument.


In scripts/account-enforcer.sh line 21:
  echo "Valid environments: ${!ENV_TO_PROFILE[@]}"
                            ^-------------------^ SC2145 (error): Argument mixes string and array. Use * or separate argument.

For more information:
  https://www.shellcheck.net/wiki/SC1128 -- The shebang must be on the first ...
  https://www.shellcheck.net/wiki/SC2145 -- Argument mixes string and array. ...
  https://www.shellcheck.net/wiki/SC2034 -- BACKEND_FILE appears unused. Veri...
```