### PR TITLE
Remove lincbrain CLI installation due to dandi CLI handling different APIs

### DIFF
--- a/envs/linc/jupyterhub-overrides.yaml
+++ b/envs/linc/jupyterhub-overrides.yaml
@@ -93,6 +93,5 @@ singleuser:
           - >
             /opt/conda/envs/allen/bin/python -m ipykernel install --user --name allen --display-name "Python (Allen SDK)";
             /opt/conda/bin/pip install --upgrade dandi;
-            /opt/conda/bin/pip install --upgrade lincbrain-cli;
             git config --global user.email "$${GITHUB_EMAIL}";
             git config --global user.name "$${GITHUB_USER}"


### PR DESCRIPTION
Simplifies JupyterHub installation due to changes in https://github.com/dandi/dandi-cli/pull/1519

Relates to 

https://github.com/dandi/dandi-cli/issues/1517#issuecomment-2456163564 and https://github.com/dandi/dandi-cli/issues/1517

cc @kabilar 