### PR TITLE
Bump Kubernetes

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -108,8 +108,11 @@ module "eks_blueprints_addons" {
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
     values = [<<EOT
-        controller:
-          image: public.ecr.aws/karpenter/controller:0.35.0@sha256:48d1246f6b2066404e300cbf3e26d0bcdc57a76531dcb634d571f4f0e050cb57
+      controller:
+        image:
+          repository: public.ecr.aws/karpenter/controller
+          tag: "0.35.0"
+          digest: "sha256:48d1246f6b2066404e300cbf3e26d0bcdc57a76531dcb634d571f4f0e050cb57"
     EOT
     ]
   }

--- a/envs/dandi/managed-jupyterhub.yaml
+++ b/envs/dandi/managed-jupyterhub.yaml
@@ -218,30 +218,6 @@ singleuser:
           display_name: Image
     - default: true
       description: 6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start.
-      display_name: MIT Workshop (tmp)
-      kubespawner_override:
-        cpu_guarantee: 6
-        cpu_limit: 12
-        image_pull_policy: Always
-        mem_guarantee: 16G
-        mem_limit: 32G
-        node_selector:
-          NodePool: cpu-on-demand
-      profile_options:
-        image:
-          choices:
-            matlab:
-              display_name: MATLAB (must provide your own license)
-              kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}-matlab
-            standard:
-              default: true
-              display_name: Standard
-              kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}
-          display_name: Image
-    - default: true
-      description: 6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start.
       display_name: Base
       kubespawner_override:
         cpu_guarantee: 6

--- a/envs/dandi/managed-jupyterhub.yaml
+++ b/envs/dandi/managed-jupyterhub.yaml
@@ -214,7 +214,31 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}
+                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
+          display_name: Image
+    - default: true
+      description: 6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start.
+      display_name: MIT Workshop (tmp)
+      kubespawner_override:
+        cpu_guarantee: 6
+        cpu_limit: 12
+        image_pull_policy: Always
+        mem_guarantee: 16G
+        mem_limit: 32G
+        node_selector:
+          NodePool: cpu-on-demand
+      profile_options:
+        image:
+          choices:
+            matlab:
+              display_name: MATLAB (must provide your own license)
+              kubespawner_override:
+                image: ${singleuser_image_repo}:${singleuser_image_tag}-matlab
+            standard:
+              default: true
+              display_name: Standard
+              kubespawner_override:
+                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
           display_name: Image
     - default: true
       description: 6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start.
@@ -238,7 +262,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}
+                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
           display_name: Image
     - description: 12C/32G up to 24C/64G. May take up to 15 mins to start.
       display_name: Medium
@@ -261,7 +285,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}
+                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
           display_name: Image
     - description: 24C/64G up to 48C/96G. May take up to 15 mins to start.
       display_name: Large
@@ -284,7 +308,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}
+                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
           display_name: Image
     - description: 8 CPU / 30 GB / 1 T4 GPU. May take up to 15 mins to start.
       display_name: T4 GPU for inference

--- a/envs/dandi/managed-jupyterhub.yaml
+++ b/envs/dandi/managed-jupyterhub.yaml
@@ -214,7 +214,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
+                image: ${singleuser_image_repo}:${singleuser_image_tag}
           display_name: Image
     - default: true
       description: 6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start.
@@ -238,7 +238,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
+                image: ${singleuser_image_repo}:${singleuser_image_tag}
           display_name: Image
     - default: true
       description: 6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start.
@@ -262,7 +262,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
+                image: ${singleuser_image_repo}:${singleuser_image_tag}
           display_name: Image
     - description: 12C/32G up to 24C/64G. May take up to 15 mins to start.
       display_name: Medium
@@ -285,7 +285,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
+                image: ${singleuser_image_repo}:${singleuser_image_tag}
           display_name: Image
     - description: 24C/64G up to 48C/96G. May take up to 15 mins to start.
       display_name: Large
@@ -308,7 +308,7 @@ singleuser:
               default: true
               display_name: Standard
               kubespawner_override:
-                image: ${singleuser_image_repo}:${singleuser_image_tag}-base
+                image: ${singleuser_image_repo}:${singleuser_image_tag}
           display_name: Image
     - description: 8 CPU / 30 GB / 1 T4 GPU. May take up to 15 mins to start.
       display_name: T4 GPU for inference

--- a/envs/shared/jupyterhub.yaml
+++ b/envs/shared/jupyterhub.yaml
@@ -50,7 +50,7 @@ singleuser:
               display_name: "Standard"
               default: true
               kubespawner_override:
-                image: "${singleuser_image_repo}:${singleuser_image_tag}-base"
+                image: "${singleuser_image_repo}:${singleuser_image_tag}"
       kubespawner_override:
         image_pull_policy: Always
         cpu_limit: 2
@@ -69,7 +69,7 @@ singleuser:
               display_name: "Standard"
               default: true
               kubespawner_override:
-                image: "${singleuser_image_repo}:${singleuser_image_tag}-base"
+                image: "${singleuser_image_repo}:${singleuser_image_tag}"
             matlab:
               display_name: "MATLAB (must provide your own license)"
               kubespawner_override:
@@ -93,7 +93,7 @@ singleuser:
               display_name: "Standard"
               default: true
               kubespawner_override:
-                image: "${singleuser_image_repo}:${singleuser_image_tag}-base"
+                image: "${singleuser_image_repo}:${singleuser_image_tag}"
             matlab:
               display_name: "MATLAB (must provide your own license)"
               kubespawner_override:
@@ -118,7 +118,7 @@ singleuser:
               display_name: "Standard"
               default: true
               kubespawner_override:
-                image: "${singleuser_image_repo}:${singleuser_image_tag}-base"
+                image: "${singleuser_image_repo}:${singleuser_image_tag}"
             matlab:
               display_name: "MATLAB (must provide your own license)"
               kubespawner_override:
@@ -141,7 +141,7 @@ singleuser:
               display_name: "Standard"
               default: true
               kubespawner_override:
-                image: "${singleuser_image_repo}:${singleuser_image_tag}-base"
+                image: "${singleuser_image_repo}:${singleuser_image_tag}"
             matlab:
               display_name: "MATLAB (must provide your own license)"
               kubespawner_override:

--- a/envs/shared/jupyterhub.yaml
+++ b/envs/shared/jupyterhub.yaml
@@ -59,30 +59,30 @@ singleuser:
         mem_guarantee: 0.5G
         node_selector:
           NodePool: default
-    - display_name: "MIT Workshop (tmp)"
-      description: "6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start."
-      profile_options:
-        image:
-          display_name: "Image"
-          choices:
-            standard:
-              display_name: "Standard"
-              default: true
-              kubespawner_override:
-                image: "${singleuser_image_repo}:${singleuser_image_tag}"
-            matlab:
-              display_name: "MATLAB (must provide your own license)"
-              kubespawner_override:
-                image: "${singleuser_image_repo}:${singleuser_image_tag}-matlab"
-      default: true
-      kubespawner_override:
-        image_pull_policy: Always
-        cpu_limit: 12
-        cpu_guarantee: 6
-        mem_limit: 32G
-        mem_guarantee: 16G
-        node_selector:
-          NodePool: cpu-on-demand
+    # - display_name: "MIT Workshop (tmp)"
+    #   description: "6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start."
+    #   profile_options:
+    #     image:
+    #       display_name: "Image"
+    #       choices:
+    #         standard:
+    #           display_name: "Standard"
+    #           default: true
+    #           kubespawner_override:
+    #             image: "${singleuser_image_repo}:${singleuser_image_tag}"
+    #         matlab:
+    #           display_name: "MATLAB (must provide your own license)"
+    #           kubespawner_override:
+    #             image: "${singleuser_image_repo}:${singleuser_image_tag}-matlab"
+    #   default: true
+    #   kubespawner_override:
+    #     image_pull_policy: Always
+    #     cpu_limit: 12
+    #     cpu_guarantee: 6
+    #     mem_limit: 32G
+    #     mem_guarantee: 16G
+    #     node_selector:
+    #       NodePool: cpu-on-demand
     - display_name: "Base"
       description: "6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start."
       profile_options:

--- a/envs/shared/jupyterhub.yaml
+++ b/envs/shared/jupyterhub.yaml
@@ -59,30 +59,30 @@ singleuser:
         mem_guarantee: 0.5G
         node_selector:
           NodePool: default
-    # - display_name: "MIT Workshop (tmp)"
-    #   description: "6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start."
-    #   profile_options:
-    #     image:
-    #       display_name: "Image"
-    #       choices:
-    #         standard:
-    #           display_name: "Standard"
-    #           default: true
-    #           kubespawner_override:
-    #             image: "${singleuser_image_repo}:${singleuser_image_tag}-base"
-    #         matlab:
-    #           display_name: "MATLAB (must provide your own license)"
-    #           kubespawner_override:
-    #             image: "${singleuser_image_repo}:${singleuser_image_tag}-matlab"
-    #   default: true
-    #   kubespawner_override:
-    #     image_pull_policy: Always
-    #     cpu_limit: 12
-    #     cpu_guarantee: 6
-    #     mem_limit: 32G
-    #     mem_guarantee: 16G
-    #     node_selector:
-    #       NodePool: cpu-on-demand
+    - display_name: "MIT Workshop (tmp)"
+      description: "6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start."
+      profile_options:
+        image:
+          display_name: "Image"
+          choices:
+            standard:
+              display_name: "Standard"
+              default: true
+              kubespawner_override:
+                image: "${singleuser_image_repo}:${singleuser_image_tag}-base"
+            matlab:
+              display_name: "MATLAB (must provide your own license)"
+              kubespawner_override:
+                image: "${singleuser_image_repo}:${singleuser_image_tag}-matlab"
+      default: true
+      kubespawner_override:
+        image_pull_policy: Always
+        cpu_limit: 12
+        cpu_guarantee: 6
+        mem_limit: 32G
+        mem_guarantee: 16G
+        node_selector:
+          NodePool: cpu-on-demand
     - display_name: "Base"
       description: "6 CPU / 16 GB up to 12C/32G. May take up to 15 mins to start."
       profile_options:

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "region" {
 
 variable "eks_cluster_version" {
   description = "EKS Cluster version"
-  default     = "1.28"
+  default     = "1.29"
   type        = string
 }
 


### PR DESCRIPTION
Here are the changes I put in place for the temporary on-demand profile for Ben's workshop. I've removed the temporary profile, but there were a few changes that are still needed.

 - bump to k8s 1.29
 - syntax change for the pinned karpenter controller
 - revert image tag to `latest` from `latest-base` (@kabilar this might end up conflicting with your PR)

@kabilar @aaronkanzer, dandihub has already been redeployed using these changes, so this is good to merge, but I'll wait a bit in case you'd like to review.

## Original, outdated notes

@aaronkanzer ~Here are the changes I pushed to dandi-hub today.~

~Not all of them should merge to the repo, I can break it up tomorrow afternoon.~