### PR TITLE
Fix tag for OpenScope image

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -17,7 +17,7 @@ jobs:
         include:
           - tag: latest
             dockerfile: Dockerfile
-          - tag: latest
+          - tag: latest-openscope
             dockerfile: Dockerfile.openscope
           - tag: latest-allensdk
             dockerfile: Dockerfile.allensdk

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -15,7 +15,7 @@ jobs:
         include:
           - tag: latest
             dockerfile: Dockerfile
-          - tag: latest
+          - tag: latest-openscope
             dockerfile: Dockerfile.openscope
           - tag: latest-allensdk
             dockerfile: Dockerfile.allensdk


### PR DESCRIPTION
I will run a `workflow_dispatch` for the `Build and Push Docker Images` GitHub Action once this is merged.