### PR TITLE
Update MatNWB version to the latest master commit

### DIFF
--- a/images/Dockerfile.matlab
+++ b/images/Dockerfile.matlab
@@ -77,7 +77,7 @@ end \n\
 % ADD HERE EXTRA ACTIONS FOR YOUR ADD-ON IF REQUIRED! \n\
 clear" >> ${STARTUP_SCRIPT}
 
-# Variables for addons management that are tied to a specific release or latest master
+# Variables for addons management that are tied to a specific release or commit
 ARG ADDONS_RELEASES="https://github.com/NeurodataWithoutBorders/matnwb/archive/2c3a4e13c9504724c08f3d937c08c730accf7685.zip \
                      https://github.com/schnitzer-lab/EXTRACT-public/archive/refs/heads/master.zip \
                      https://github.com/bahanonu/ciatah/archive/refs/heads/master.zip"

--- a/images/Dockerfile.matlab
+++ b/images/Dockerfile.matlab
@@ -72,13 +72,13 @@ addons = setdiff({addons([addons.isdir]).name}, {'.', '..'}); \n\
 for addon_idx = 1:numel(addons) \n\
     addpath(genpath(strcat('${ADDONS_DIR}/', addons{addon_idx}))); \n\
 end \n\
-generateCore();  % Generate the most recent nwb-schema \n\
+% generateCore();  % Generate the most recent nwb-schema \n\
 % ciapkg.io.loadDependencies('guiEnabled', 0);  % Load dependencies for CIAtah \n\
 % ADD HERE EXTRA ACTIONS FOR YOUR ADD-ON IF REQUIRED! \n\
 clear" >> ${STARTUP_SCRIPT}
 
-# Variables for addons management that are tied to a specific release
-ARG ADDONS_RELEASES="https://github.com/NeurodataWithoutBorders/matnwb/archive/refs/tags/2.8.0.zip \
+# Variables for addons management that are tied to a specific release or latest master
+ARG ADDONS_RELEASES="https://github.com/NeurodataWithoutBorders/matnwb/archive/refs/heads/master.zip \
                      https://github.com/schnitzer-lab/EXTRACT-public/archive/refs/heads/master.zip \
                      https://github.com/bahanonu/ciatah/archive/refs/heads/master.zip"
 

--- a/images/Dockerfile.matlab
+++ b/images/Dockerfile.matlab
@@ -78,7 +78,7 @@ end \n\
 clear" >> ${STARTUP_SCRIPT}
 
 # Variables for addons management that are tied to a specific release or latest master
-ARG ADDONS_RELEASES="https://github.com/NeurodataWithoutBorders/matnwb/archive/refs/heads/master.zip \
+ARG ADDONS_RELEASES="https://github.com/NeurodataWithoutBorders/matnwb/archive/2c3a4e13c9504724c08f3d937c08c730accf7685.zip \
                      https://github.com/schnitzer-lab/EXTRACT-public/archive/refs/heads/master.zip \
                      https://github.com/bahanonu/ciatah/archive/refs/heads/master.zip"
 


### PR DESCRIPTION
This PR updates the version of MatNWB to the lastest commit on master to deal with the lastest modifications that includes some warning messages when loading NWB files with different schema version. 

@kabilar I know we proposed an update not so long time ago of the MatNWB version, but this last update should tackle better some issues we encountered with the loading of different NWB versions, and we will be able to go back to a dedicated version when the new patch will be included in a new release.